### PR TITLE
Add -r option to read-frequency to enable filtering modification calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,7 @@ mbtools read-frequency input.bam > output.tsv
 
 # calculate the modification frequency for each region in a bed file
 mbtools region-frequency -r regions.bed input.bam > output.tsv
+
+# calculate the modification frequency for each read segmented by regions in a bed file (good for long reads spanning multiple regions)
+mbtools region-read-frequency -r regions.bed input.bam > output.tsv
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,10 +267,22 @@ fn main() {
                 .arg(Arg::with_name("input-bam")
                     .required(true)
                     .index(1)
+                    .help("the input bam file to process")))
+        .subcommand(SubCommand::with_name("read-region-frequency")
+                .about("calculate the frequency of modified bases per read filtered across regions within the BED file")
+                .arg(Arg::with_name("probability-threshold")
+                    .short("t")
+                    .long("probability-threshold")
+                    .takes_value(true)
+                    .help("only use calls where the probability of being modified/not modified is at least t"))
+                .arg(Arg::with_name("input-bam")
+                    .required(true)
+                    .index(1)
                     .help("the input bam file to process"))
                 .arg(Arg::with_name("region-bed")
                     .short("r")
                     .long("region-bed")
+                    .required(true)
                     .takes_value(true)
                     .help("bed file containing the regions to calculate modification frequencies for")))
         .subcommand(SubCommand::with_name("region-frequency")
@@ -323,11 +335,17 @@ fn main() {
                                       matches.value_of("input-bam").unwrap())
     }
     
+    if let Some(matches) = matches.subcommand_matches("read-region-frequency") {
+
+        // TODO: set to nanopolish default LLR
+        calculate_read_region_frequency(calling_threshold,
+                                    matches.value_of("region-bed").unwrap(),
+                                    matches.value_of("input-bam").unwrap())
+    }
     if let Some(matches) = matches.subcommand_matches("read-frequency") {
 
         // TODO: set to nanopolish default LLR
         calculate_read_frequency(calling_threshold,
-                                    matches.value_of("region-bed").unwrap_or("none"),
                                     matches.value_of("input-bam").unwrap())
     }
 
@@ -402,7 +420,7 @@ fn calculate_reference_frequency(threshold: f64, collapse_strands: bool, input_b
     eprintln!("Processed {} reads in {:?}. Mean depth: {:.2} mean modification frequency: {:.2}", reads_processed, start.elapsed(), mean_depth, mean_frequency);
 }
 
-fn calculate_read_frequency(threshold: f64, region_bed: &str, input_bam: &str) {
+fn calculate_read_frequency(threshold: f64, input_bam: &str) {
 
     let mut bam = bam::Reader::from_path(input_bam).expect("Could not read input bam file:");
     let header_view = bam.header().clone();
@@ -412,122 +430,46 @@ fn calculate_read_frequency(threshold: f64, region_bed: &str, input_bam: &str) {
     let mut summary_total = 0;
     let mut summary_modified = 0;
 
-    // If a region bed file is not provided calculate the frequency for the entire read
-    if region_bed == "none" {
+    eprintln!("calculating read modifications with t:{} on file {}", threshold, input_bam);
+    for r in bam.records() {
+        let record = r.unwrap();
 
-        eprintln!("calculating read modifications with t:{} on file {}", threshold, input_bam);
-        for r in bam.records() {
-            let record = r.unwrap();
+        if record.is_unmapped() {
+            continue;
+        }
 
-            if record.is_unmapped() {
-                continue;
-            }
+        let mut total_calls = 0;
+        let mut total_modified = 0;
 
-            let mut total_calls = 0;
-            let mut total_modified = 0;
+        if let Some(rm) = ReadModifications::from_bam_record(&record) {
 
-            if let Some(rm) = ReadModifications::from_bam_record(&record) {
-
-                for call in rm.modification_calls {
-                    if call.is_confident(threshold) {
-                        total_calls += 1;
-                        total_modified += call.is_modified() as usize;
-                    }
+            for call in rm.modification_calls {
+                if call.is_confident(threshold) {
+                    total_calls += 1;
+                    total_modified += call.is_modified() as usize;
                 }
             }
+        }
 
-            let qname = std::str::from_utf8(record.qname()).unwrap();
-            let strand = if record.is_reverse() { '-' } else { '+' };
-            let mod_frequency = if total_calls > 0 { total_modified as f64 / total_calls as f64 } else { f64::NAN };
-            let contig = String::from_utf8_lossy(header_view.tid2name(record.tid() as u32));
-            let start_position = record.pos();
-            let end_position = record.reference_end();
-            let alignment_length = end_position - start_position + 1;
-            println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}", 
-                qname, contig, record.pos(), end_position, alignment_length, 
-                strand, record.mapq(), total_calls, total_modified, mod_frequency);
-        
-            // for the ending summary line
-            reads_processed += 1;
-            summary_total += total_calls;
-            summary_modified += total_modified;
-        }
-        
-        let summary_frequency = if summary_total > 0 { summary_modified as f64 / summary_total as f64 } else { f64::NAN };
-        eprintln!("Processed {} reads in {:?}. Mean modification frequency: {:.2}", reads_processed, start.elapsed(), summary_frequency);
-    } else {
-        // read bed file into a data structure we can use to make intervaltrees from
-        // this maps from tid to a vector of intervals, with an interval index for each
-        eprintln!("calculating read modifications with t:{} on file {}\n Modifications filtered to those within the regions of {}", threshold, input_bam, region_bed);
-        let mut bed_reader = csv::ReaderBuilder::new().delimiter(b'\t').from_path(region_bed).expect("could not open bed file");
-        let mut region_desc_by_chr = HashMap::<u32, Vec<(Range<usize>, usize)>>::new();
-
-        for r in bed_reader.records() {
-            let record = r.expect("could not parse bed record");
-            if let Some(tid) = header_view.tid(record[0].as_bytes()) {
-                let start: usize = record[1].parse().unwrap();
-                let end: usize = record[2].parse().unwrap();
-                let region_desc = region_desc_by_chr.entry(tid).or_insert( Vec::new() );
-                region_desc.push( (start..end, 0) );
-            }
-        }
-        // build tid -> intervaltree map
-        // the intervaltree allows us to look up an interval_idx for a given chromosome and position
-        let mut interval_trees = HashMap::<u32, IntervalTree<usize, usize>>::new();
-        for (tid, region_desc) in region_desc_by_chr {
-            interval_trees.insert(tid, region_desc.iter().cloned().collect() );
-        }
-        
-        // iterate over bam records
-        for r in bam.records() {
-            let record = r.unwrap();
-            if record.is_unmapped() {
-                continue;
-            }
-            // Check if the read overlaps any of the regions
-            // for every region the read overlaps, we write a record for that region
-            // counting only the modifications calls in that region
-            let tid = record.tid() as u32;
-            if let Some(tree) = interval_trees.get(&tid) {
-                let start = record.pos() as usize;
-                let end = record.reference_end() as usize;
-                for region in tree.query(start..end) {
-                     let mut total_calls = 0;
-                     let mut total_modified = 0;
-                     let start_position = max(start, region.clone().range.start);
-                     let end_position = min(end, region.clone().range.end);
-                     // get the read modifications for this read
-                     if let Some(rm) = ReadModifications::from_bam_record(&record) {
-                         // for each modification call, check if it is in the region
-                         for call in rm.modification_calls {
-                            if call.is_confident(threshold) && call.reference_index.is_some() {
-                                let reference_position = call.reference_index.unwrap().clone();
-                                if reference_position >= start_position && reference_position <= end_position {
-                                    total_calls += 1;
-                                    total_modified += call.is_modified() as usize;
-                                }
-                            }
-                        }
-                    }
-                    let qname = std::str::from_utf8(record.qname()).unwrap();
-                    let strand = if record.is_reverse() { '-' } else { '+' };
-                    let mod_frequency = if total_calls > 0 { total_modified as f64 / total_calls as f64 } else { f64::NAN };
-                    let contig = String::from_utf8_lossy(header_view.tid2name(record.tid() as u32));
-                    let alignment_length = record.reference_end() - record.pos() + 1;
-                    println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}", 
-                        qname, contig, start_position, end_position, alignment_length, 
-                        strand, record.mapq(), total_calls, total_modified, mod_frequency);
-                    summary_total += total_calls;
-                }
-            }
-            // for the ending summary line
-            reads_processed += 1;
-        }
-        let summary_frequency = if summary_total > 0 { summary_modified as f64 / summary_total as f64 } else { f64::NAN };
-        eprintln!("Processed {} reads in {:?}. Mean modification frequency: {:.2}", reads_processed, start.elapsed(), summary_frequency);
+        let qname = std::str::from_utf8(record.qname()).unwrap();
+        let strand = if record.is_reverse() { '-' } else { '+' };
+        let mod_frequency = if total_calls > 0 { total_modified as f64 / total_calls as f64 } else { f64::NAN };
+        let contig = String::from_utf8_lossy(header_view.tid2name(record.tid() as u32));
+        let start_position = record.pos();
+        let end_position = record.reference_end();
+        let alignment_length = end_position - start_position + 1;
+        println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}", 
+            qname, contig, record.pos(), end_position, alignment_length, 
+            strand, record.mapq(), total_calls, total_modified, mod_frequency);
+    
+        // for the ending summary line
+        reads_processed += 1;
+        summary_total += total_calls;
+        summary_modified += total_modified;
     }
+    let summary_frequency = if summary_total > 0 { summary_modified as f64 / summary_total as f64 } else { f64::NAN };
+    eprintln!("Processed {} reads in {:?}. Mean modification frequency: {:.2}", reads_processed, start.elapsed(), summary_frequency);
 }
-
 struct RegionStats {
     chromosome: String,
     start: usize,
@@ -540,25 +482,8 @@ struct RegionStats {
     m_reads: usize,
     x_reads: usize
 }
-
-fn calculate_region_frequency(call_threshold: f64, 
-                              classification_threshold: f64, 
-                              classification_min_sites: usize, 
-                              region_bed: &str, 
-                              input_bam: &str, 
-                              filter_to_cpg: bool, 
-                              reference_genome: &str) {
-    eprintln!("calculating modification frequency for regions from {} on file {}", region_bed, input_bam);
-    let faidx = match filter_to_cpg {
-        true => Some(faidx::Reader::from_path(reference_genome).expect("Could not read reference genome:")),
-        false => None
-    };
-    
-    let mut bam = bam::Reader::from_path(input_bam).expect("Could not read input bam file:");
-    let header = bam::Header::from_template(bam.header());
-    let header_view = bam::HeaderView::from_header(&header);
-
-    // read bed file into a data structure we can use to make intervaltrees from
+fn interval_tree_from_bed(region_bed: &str, header_view: bam::HeaderView) -> (HashMap<u32, IntervalTree<usize, usize>>, Vec<RegionStats>) {
+    // Read bed file into a data structure we can use to make intervaltrees from
     // this maps from tid to a vector of intervals, with an interval index for each
     let mut bed_reader = csv::ReaderBuilder::new().delimiter(b'\t').from_path(region_bed).expect("could not open bed file");
     let mut region_desc_by_chr = HashMap::<u32, Vec<(Range<usize>, usize)>>::new();
@@ -588,13 +513,95 @@ fn calculate_region_frequency(call_threshold: f64,
             region_data.push( init );
         }
     }
-
     // build tid -> intervaltree map
     // the intervaltree allows us to look up an interval_idx for a given chromosome and position
     let mut interval_trees = HashMap::<u32, IntervalTree<usize, usize>>::new();
     for (tid, region_desc) in region_desc_by_chr {
         interval_trees.insert(tid, region_desc.iter().cloned().collect());
     }
+    (interval_trees, region_data)
+}
+
+fn calculate_read_region_frequency(threshold: f64, region_bed: &str, input_bam: &str) {
+
+    eprintln!("calculating read modifications with t:{} on file {}\n Modifications filtered to those within the regions of {}", threshold, input_bam, region_bed);
+    println!("read_name\tchromosome\tstart_position\tend_position\talignment_length\tstrand\tmapping_quality\ttotal_calls\tmodified_calls\tmodification_frequency");
+    let mut bam = bam::Reader::from_path(input_bam).expect("Could not read input bam file:");
+    let header_view = bam.header().clone();
+    let start = Instant::now();
+    let mut reads_processed = 0;
+    let mut summary_total = 0;
+    let mut summary_modified = 0;
+    let (interval_trees, _) = interval_tree_from_bed(region_bed, header_view.clone());
+        
+    // iterate over bam records
+    for r in bam.records() {
+        let record = r.unwrap();
+        if record.is_unmapped() {
+            continue;
+        }
+        // Check if the read overlaps any of the regions
+        // for every region the read overlaps, we write a record for that region
+        // counting only the modifications calls in that region
+        let tid = record.tid() as u32;
+        if let Some(tree) = interval_trees.get(&tid) {
+            let start = record.pos() as usize;
+            let end = record.reference_end() as usize;
+            if let Some(rm) = ReadModifications::from_bam_record(&record) {
+                for region in tree.query(start..end) {
+                     let mut total_calls = 0;
+                     let mut total_modified = 0;
+                     let start_position = max(start, region.clone().range.start);
+                     let end_position = min(end, region.clone().range.end);
+                     // get the read modifications for this read
+                     // for each modification call, check if it is in the region
+                     for call in &rm.modification_calls {
+                        if call.is_confident(threshold) && call.reference_index.is_some() {
+                            let reference_position = call.reference_index.unwrap().clone();
+                            if reference_position >= start_position && reference_position <= end_position {
+                                total_calls += 1;
+                                total_modified += call.is_modified() as usize;
+                            }
+                        }
+                    }
+                    let qname = std::str::from_utf8(record.qname()).unwrap();
+                    let strand = if record.is_reverse() { '-' } else { '+' };
+                    let mod_frequency = if total_calls > 0 { total_modified as f64 / total_calls as f64 } else { f64::NAN };
+                    let contig = String::from_utf8_lossy(header_view.tid2name(record.tid() as u32));
+                    let alignment_length = record.reference_end() - record.pos() + 1;
+                    println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}", 
+                        qname, contig, start_position, end_position, alignment_length, 
+                        strand, record.mapq(), total_calls, total_modified, mod_frequency);
+                    summary_total += total_calls;
+                    summary_modified += total_modified;
+                }
+            }
+        }
+        // for the ending summary line
+        reads_processed += 1;
+    }
+    let summary_frequency = if summary_total > 0 { summary_modified as f64 / summary_total as f64 } else { f64::NAN };
+    eprintln!("Processed {} reads in {:?}. Mean modification frequency: {:.2}", reads_processed, start.elapsed(), summary_frequency);
+}
+
+fn calculate_region_frequency(call_threshold: f64, 
+                              classification_threshold: f64, 
+                              classification_min_sites: usize, 
+                              region_bed: &str, 
+                              input_bam: &str, 
+                              filter_to_cpg: bool, 
+                              reference_genome: &str) {
+    eprintln!("calculating modification frequency for regions from {} on file {}", region_bed, input_bam);
+    let faidx = match filter_to_cpg {
+        true => Some(faidx::Reader::from_path(reference_genome).expect("Could not read reference genome:")),
+        false => None
+    };
+    
+    let mut bam = bam::Reader::from_path(input_bam).expect("Could not read input bam file:");
+    let header = bam::Header::from_template(bam.header());
+    let header_view = bam::HeaderView::from_header(&header);
+
+    let (interval_trees, mut region_data) = interval_tree_from_bed(region_bed, header_view.clone());
 
     let mut curr_chromosome_id = -1;
     let mut curr_chromosome_seq = String::new();


### PR DESCRIPTION
Mbtools `read-frequency` outputs the total modification calls per every read in the Bam file.

The `-r` option filters for reads which intersect in regions provided by a `bed` file
If a read spans two of such regions, two entries are created in the output with identical `read_names` but can be distinguished by their `start_position` and `end_position` which indicates the partition of the read the modification calls are associated with.